### PR TITLE
Provide an access to the underlying ProcessHandle.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+## 0.1.0.2
+
+* Introduce 'unsafeProcessHandle' function
+
 ## 0.1.0.1
 
 * Fix bug in `waitForProcess` that caused exit code to be lost

--- a/src/System/Process/Typed.hs
+++ b/src/System/Process/Typed.hs
@@ -844,5 +844,7 @@ instance Exception ByteStringOutputException
 -- 'System.Process.terminateProcess' or by sending signal,
 -- 'stopProcess' should be called either way in order to cleanup resources
 -- allocated by the @typed-process@.
+--
+-- @since 0.1.0.2
 unsafeProcessHandle :: Process stdin stdout stderr -> P.ProcessHandle
 unsafeProcessHandle = pHandle

--- a/typed-process.cabal
+++ b/typed-process.cabal
@@ -1,5 +1,5 @@
 name:                typed-process
-version:             0.1.0.1
+version:             0.1.0.2
 synopsis:            Run external processes, with strong typing of streams
 description:         Please see README.md
 homepage:            https://haskell-lang.org/library/typed-process


### PR DESCRIPTION
Introduce 'unsafeProcessHandle' call that provide an
access to the underlying ProcessHandle, so user can
use any platform specific or sophisticated method
of interacting with process.