### PR TITLE
Fix doc bug

### DIFF
--- a/src/System/Process/Typed.hs
+++ b/src/System/Process/Typed.hs
@@ -799,12 +799,13 @@ readProcessStdout_ pc =
   where
     pc' = setStdout byteStringOutput pc
 
--- | Same as 'readProcess', but only read the stderr of the process. Original settings for stderr remain.
+-- | Same as 'readProcess', but only read the stderr of the process.
+-- Original settings for stdout remain.
 --
 -- @since 0.2.1.0
 readProcessStderr
   :: MonadIO m
-  => ProcessConfig stdin stderrIgnored stderr
+  => ProcessConfig stdin stdout stderrIgnored
   -> m (ExitCode, L.ByteString)
 readProcessStderr pc =
     liftIO $ withProcess pc' $ \p -> atomically $ (,)
@@ -819,7 +820,7 @@ readProcessStderr pc =
 -- @since 0.2.1.0
 readProcessStderr_
   :: MonadIO m
-  => ProcessConfig stdin stderrIgnored stderr
+  => ProcessConfig stdin stdout stderrIgnored
   -> m L.ByteString
 readProcessStderr_ pc =
     liftIO $ withProcess pc' $ \p -> atomically $ do


### PR DESCRIPTION
readProcessStderr and readProcessStderr_ have incorrect
documentation and misleading type variables in their type
signatures.  Correct these errors.