### PR TITLE
Provide a convenience function to interleave stderr with stdout

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+## 0.2.4.0
+
+* Add `readProcessInterleaved` and `readProcessInterleaved_` to support
+  capturing output from stdout and stderr in a single ByteString value.
+
 ## 0.2.3.0
 
 * Add support for the single-threaded runtime via polling

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:        typed-process
-version:     0.2.3.0
+version:     0.2.4.0
 synopsis:    Run external processes, with strong typing of streams
 description: Please see the tutorial at <https://haskell-lang.org/library/typed-process>
 category:    System

--- a/src/System/Process/Typed.hs
+++ b/src/System/Process/Typed.hs
@@ -97,7 +97,7 @@ import Control.Monad (void)
 import Control.Monad.IO.Class
 import qualified System.Process as P
 import Data.Typeable (Typeable)
-import System.IO (Handle, hClose, stdout)
+import System.IO (Handle, hClose)
 import System.IO.Error (isPermissionError)
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (async, cancel, waitCatch)
@@ -536,7 +536,18 @@ byteStringInput lbs = mkStreamSpec P.CreatePipe $ \_ (Just h) -> do
 --
 -- @since 0.1.0.0
 byteStringOutput :: StreamSpec 'STOutput (STM L.ByteString)
-byteStringOutput = mkStreamSpec P.CreatePipe $ \pc (Just h) -> do
+byteStringOutput = mkStreamSpec P.CreatePipe $ \pc (Just h) -> byteStringFromHandle pc h
+
+-- | Helper function (not exposed) for both 'byteStringOutput' and
+-- 'withProcessInterleave'. This will consume all of the output from
+-- the given 'Handle' in a separate thread and provide access to the
+-- resulting 'L.ByteString' via STM. Second action will close the
+-- reader handle.
+byteStringFromHandle
+  :: ProcessConfig () () ()
+  -> Handle -- ^ reader handle
+  -> IO (STM L.ByteString, IO ())
+byteStringFromHandle pc h = do
     mvar <- newEmptyTMVarIO
 
     void $ async $ do
@@ -834,6 +845,26 @@ readProcessStderr_ pc =
   where
     pc' = setStderr byteStringOutput pc
 
+withProcessInterleave
+  :: ProcessConfig stdin stdoutIgnored stderrIgnored
+  -> (Process stdin (STM L.ByteString) () -> IO a)
+  -> IO a
+withProcessInterleave pc inner = do
+    -- Create a pipe to be shared for both stdout and stderr
+    (readEnd, writeEnd) <- P.createPipe
+
+    -- Use the writer end of the pipe for both stdout and stderr. For
+    -- the stdout half, use byteStringFromHandle to read the data into
+    -- a lazy ByteString in memory.
+    let pc' = setStdout (mkStreamSpec (P.UseHandle writeEnd) (\pc'' Nothing -> byteStringFromHandle pc'' readEnd))
+            $ setStderr (useHandleOpen writeEnd)
+              pc
+    withProcess pc' $ \p -> do
+      -- Now that the process is forked, close the writer end of this
+      -- pipe, otherwise the reader end will never give an EOF.
+      hClose writeEnd
+      inner p
+
 -- | Same as 'readProcess', but interleaves stderr with stdout.
 --
 -- Motivation: Use this function if you need stdout interleaved with stderr
@@ -844,15 +875,12 @@ readProcessInterleaved
   :: MonadIO m
   => ProcessConfig stdin stdoutIgnored stderrIgnored
   -> m (ExitCode, L.ByteString)
-readProcessInterleaved pc = do
-  (readEnd, writeEnd) <- liftIO P.createPipe
-  let pc' = setStdin closed
-          $ setStderr (useHandleOpen writeEnd)
-          $ setStdout (useHandleOpen writeEnd) pc
-  liftIO $ withProcess pc' $ \p -> do
-    out <- readHandle (pConfig p) readEnd >>= atomically
-    exit <- atomically $ waitExitCodeSTM p
-    pure (exit, out)
+readProcessInterleaved pc =
+    liftIO $
+    withProcessInterleave pc $ \p ->
+    atomically $ (,)
+      <$> waitExitCodeSTM p
+      <*> getStdout p
 
 -- | Same as 'readProcessInterleaved', but instead of returning the 'ExitCode',
 -- checks it with 'checkExitCode'.
@@ -862,33 +890,14 @@ readProcessInterleaved_
   :: MonadIO m
   => ProcessConfig stdin stdoutIgnored stderrIgnored
   -> m L.ByteString
-readProcessInterleaved_ pc = do
-    (readEnd, writeEnd) <- liftIO P.createPipe
-    let pc' = setStdout (useHandleOpen writeEnd)
-              $ setStderr (useHandleOpen writeEnd)
-              $ setStdin closed pc
-    liftIO $ withProcess pc' $ \p -> do
-        stdout' <- readHandle (pConfig p) readEnd >>= atomically
-        atomically $ checkExitCodeSTM p `catchSTM` \ece -> throwSTM ece
-            { eceStderr = stdout'
-            }
-        return stdout'
-
-readHandle :: ProcessConfig () () () -> Handle -> IO (STM L.ByteString)
-readHandle pc h = do
-    mvar <- newEmptyTMVarIO
-
-    void $ async $ do
-        let loop front = do
-                bs <- S.hGetSome h defaultChunkSize
-                if S.null bs
-                    then atomically $ putTMVar mvar $ Right $ L.fromChunks $ front []
-                    else loop $ front . (bs:)
-        loop id `catch` \e -> do
-            atomically $ void $ tryPutTMVar mvar $ Left $ ByteStringOutputException e pc
-            throwIO e
-    return (readTMVar mvar >>= either throwSTM pure)
-
+readProcessInterleaved_ pc =
+    liftIO $ do
+    withProcessInterleave pc $ \p -> atomically $ do
+      stdout' <- getStdout p
+      checkExitCodeSTM p `catchSTM` \ece -> throwSTM ece
+        { eceStdout = stdout'
+        }
+      return stdout'
 
 -- | Run the given process, wait for it to exit, and returns its
 -- 'ExitCode'.

--- a/test/System/Process/TypedSpec.hs
+++ b/test/System/Process/TypedSpec.hs
@@ -109,5 +109,10 @@ spec = do
         hClose h
 
         let config = proc "sh" [fp]
-        (result, lbs) <- readProcessInterleaved config
-        lbs `shouldBe` "stdout\nstderr\nstdout\n"
+        (result, lbs1) <- readProcessInterleaved config
+        result `shouldBe` ExitSuccess
+        lbs2 <- readProcessInterleaved_ config
+        lbs1 `shouldBe` lbs2
+
+        let expected = "stdout\nstderr\nstdout\n"
+        L.take (L.length expected) lbs1 `shouldBe` expected

--- a/test/System/Process/TypedSpec.hs
+++ b/test/System/Process/TypedSpec.hs
@@ -86,3 +86,28 @@ spec = do
         let encoded = S.filter (/= 10) $ L.toStrict lbs
         raw <- S.readFile fp
         encoded `shouldBe` B64.encode raw
+
+    it "interleaved output" $ withSystemTempFile "interleaved-output" $ \fp h -> do
+        S.hPut h "\necho 'stdout'\n>&2 echo 'stderr'\necho 'stdout'"
+        hClose h
+
+        let config = proc "sh" [fp]
+        -- Assert, that our bash script doesn't send output only to stdout and
+        -- we assume that we captured from stderr as well
+        onlyErr <- readProcessStderr_ (setStdout createPipe config)
+        onlyErr `shouldBe` "stderr\n"
+
+        (res, lbs1) <- readProcessInterleaved config
+        res `shouldBe` ExitSuccess
+        lbs1 `shouldBe` "stdout\nstderr\nstdout\n"
+
+        lbs2 <- readProcessInterleaved_ config
+        lbs1 `shouldBe` lbs2
+
+    it "interleaved output handles large data" $ withSystemTempFile "interleaved-output" $ \fp h -> do
+        S.hPut h "\nfor i in {1..4064}; do\necho 'stdout';\n>&2 echo 'stderr';\necho 'stdout';\ndone"
+        hClose h
+
+        let config = proc "sh" [fp]
+        (result, lbs) <- readProcessInterleaved config
+        lbs `shouldBe` "stdout\nstderr\nstdout\n"


### PR DESCRIPTION
This patch adds a convenience function which allows to interleave stderr with
stdout output. The process' stderr is redirected to stdout.

Main motivation to use such a function is for debugging process output. An
example is writing acceptance tests. In order to figure out when errors
correlate with a behaviour it is much easier to see both stdout and stderr
output in comparison to have two separate process outputs.

Fixes https://github.com/fpco/typed-process/issues/16