### PR TITLE
Properly bracket pipe created in withProcessInterleave

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+## 0.2.4.1
+
+* Fix a `Handle` leak in `withProcessInterleave` and its derivatives.
+
 ## 0.2.4.0
 
 * Add `readProcessInterleaved` and `readProcessInterleaved_` to support

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:        typed-process
-version:     0.2.4.0
+version:     0.2.4.1
 synopsis:    Run external processes, with strong typing of streams
 description: Please see the tutorial at <https://haskell-lang.org/library/typed-process>
 category:    System

--- a/src/System/Process/Typed.hs
+++ b/src/System/Process/Typed.hs
@@ -849,21 +849,20 @@ withProcessInterleave
   :: ProcessConfig stdin stdoutIgnored stderrIgnored
   -> (Process stdin (STM L.ByteString) () -> IO a)
   -> IO a
-withProcessInterleave pc inner = do
+withProcessInterleave pc inner =
     -- Create a pipe to be shared for both stdout and stderr
-    (readEnd, writeEnd) <- P.createPipe
-
-    -- Use the writer end of the pipe for both stdout and stderr. For
-    -- the stdout half, use byteStringFromHandle to read the data into
-    -- a lazy ByteString in memory.
-    let pc' = setStdout (mkStreamSpec (P.UseHandle writeEnd) (\pc'' Nothing -> byteStringFromHandle pc'' readEnd))
-            $ setStderr (useHandleOpen writeEnd)
-              pc
-    withProcess pc' $ \p -> do
-      -- Now that the process is forked, close the writer end of this
-      -- pipe, otherwise the reader end will never give an EOF.
-      hClose writeEnd
-      inner p
+    bracket P.createPipe (\(r, w) -> hClose r >> hClose w) $ \(readEnd, writeEnd) -> do
+        -- Use the writer end of the pipe for both stdout and stderr. For
+        -- the stdout half, use byteStringFromHandle to read the data into
+        -- a lazy ByteString in memory.
+        let pc' = setStdout (mkStreamSpec (P.UseHandle writeEnd) (\pc'' Nothing -> byteStringFromHandle pc'' readEnd))
+                $ setStderr (useHandleOpen writeEnd)
+                  pc
+        withProcess pc' $ \p -> do
+          -- Now that the process is forked, close the writer end of this
+          -- pipe, otherwise the reader end will never give an EOF.
+          hClose writeEnd
+          inner p
 
 -- | Same as 'readProcess', but interleaves stderr with stdout.
 --


### PR DESCRIPTION
Fixes #19 

I'm not sure if closing read side first or write side first matters here but I can't think of a reason why it would.