### PR TITLE
Introduce MonadUnliftIO.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *~
 tarballs/
 /typed-process.cabal
+stack.yaml.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,19 +76,19 @@ matrix:
   #  compiler: ": #stack 7.8.4"
   #  addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack ARGS="--resolver lts-3"
+  - env: BUILD=stack ARGS="--resolver lts-3 --stack-yaml stack-lts-3.yaml"
     compiler: ": #stack 7.10.2"
     addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack ARGS="--resolver lts-6"
+  - env: BUILD=stack ARGS="--resolver lts-6 --stack-yaml stack-lts-6.yaml"
     compiler: ": #stack 7.10.3"
     addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack ARGS="--resolver lts-7"
+  - env: BUILD=stack ARGS="--resolver lts-7 --stack-yaml stack-lts-7.yaml"
     compiler: ": #stack 8.0.1"
     addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack ARGS="--resolver lts-9"
+  - env: BUILD=stack ARGS="--resolver lts-9 --stack-yaml stack-lts-9.yaml"
     compiler: ": #stack 8.0.2"
     addons: {apt: {packages: [libgmp-dev]}}
 
@@ -107,19 +107,19 @@ matrix:
   #  compiler: ": #stack 7.8.4 osx"
   #  os: osx
 
-  - env: BUILD=stack ARGS="--resolver lts-3"
+  - env: BUILD=stack ARGS="--resolver lts-3 --stack-yaml stack-lts-3.yaml"
     compiler: ": #stack 7.10.2 osx"
     os: osx
 
-  - env: BUILD=stack ARGS="--resolver lts-6"
+  - env: BUILD=stack ARGS="--resolver lts-6 --stack-yaml stack-lts-6.yaml"
     compiler: ": #stack 7.10.3 osx"
     os: osx
 
-  - env: BUILD=stack ARGS="--resolver lts-7"
+  - env: BUILD=stack ARGS="--resolver lts-7 --stack-yaml stack-lts-7.yaml"
     compiler: ": #stack 8.0.1 osx"
     os: osx
 
-  - env: BUILD=stack ARGS="--resolver lts-9"
+  - env: BUILD=stack ARGS="--resolver lts-9 --stack-yaml stack-lts-9.yaml"
     compiler: ": #stack 8.0.2 osx"
     os: osx
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,9 +19,9 @@ environment:
 
   # Compiler does not work on AppVeyor
   #- ARGS: "--resolver lts-3"
-  - ARGS: "--resolver lts-6"
-  - ARGS: "--resolver lts-7"
-  - ARGS: "--resolver lts-9"
+  - ARGS: "--resolver lts-6 --stack-yaml stack-lts-6.yaml"
+  - ARGS: "--resolver lts-7 --stack-yaml stack-lts-7.yaml"
+  - ARGS: "--resolver lts-9 --stack-yaml stack-lts-9.yaml"
   - ARGS: "--resolver lts-11"
   #- ARGS: "--resolver nightly"
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:        typed-process
-version:     0.2.5.0
+version:     0.2.6.0
 synopsis:    Run external processes, with strong typing of streams
 description: Please see the tutorial at <https://haskell-lang.org/library/typed-process>
 category:    System
@@ -20,6 +20,7 @@ dependencies:
 - process >=1.2
 - stm
 - transformers
+- unliftio-core
 
 library:
   source-dirs: src

--- a/stack-lts-3.yaml
+++ b/stack-lts-3.yaml
@@ -1,0 +1,4 @@
+resolver: lts-3.22
+extra-deps:
+- unliftio-core-0.1.2.0@sha256:7f9b48adef8e36da0202e6e70a733a5e210263ed4177c93e47a4b3f89694194b,1081
+

--- a/stack-lts-6.yaml
+++ b/stack-lts-6.yaml
@@ -1,0 +1,4 @@
+resolver: lts-6.35
+extra-deps:
+- unliftio-core-0.1.2.0@sha256:7f9b48adef8e36da0202e6e70a733a5e210263ed4177c93e47a4b3f89694194b,1081
+

--- a/stack-lts-7.yaml
+++ b/stack-lts-7.yaml
@@ -1,0 +1,4 @@
+resolver: lts-7.24
+extra-deps:
+- unliftio-core-0.1.2.0@sha256:7f9b48adef8e36da0202e6e70a733a5e210263ed4177c93e47a4b3f89694194b,1081
+

--- a/stack-lts-9.yaml
+++ b/stack-lts-9.yaml
@@ -1,0 +1,2 @@
+resolver: lts-9.21
+

--- a/test/System/Process/TypedSpec.hs
+++ b/test/System/Process/TypedSpec.hs
@@ -112,14 +112,14 @@ spec = do
         raw <- S.readFile fp
         encoded `shouldBe` B64.encode raw
 
-    describe "withProcessWait" $ do
+    describe "withProcessWait" $
         it "succeeds with sleep" $ do
           p <- withProcessWait (proc "sleep" ["1"]) pure
-          checkExitCode p
+          checkExitCode p :: IO ()
 
-    describe "withProcessWait_" $ do
-        it "succeeds with sleep" $ do
-          withProcessWait_ (proc "sleep" ["1"]) $ const $ pure ()
+    describe "withProcessWait_" $
+        it "succeeds with sleep"
+           ((withProcessWait_ (proc "sleep" ["1"]) $ const $ pure ()) :: IO ())
 
     -- These tests fail on older GHCs/process package versions
     -- because, apparently, waitForProcess isn't interruptible. See


### PR DESCRIPTION
With MonadUnliftIO in place, per @snoyberg, "rio and conduit-extra won't have
to carry around their own modified versions of functions." With the burden of
more dependencies.

No functional changes. With all those reexported functions in unliftio
package, the change mostly is replacing type signatures.

This fixes issue #28. `stack test` passed.