### PR TITLE
Regression test 38

### DIFF
--- a/src/System/Process/Typed.hs
+++ b/src/System/Process/Typed.hs
@@ -768,6 +768,7 @@ startProcess pConfig'@ProcessConfig {..} = liftIO $ do
                       -- then call waitForProcess ourselves
                       Left _ -> do
                           eres <- try $ P.terminateProcess pHandle
+                          P.getProcessExitCode pHandle
                           ec <-
                             case eres of
                               Left e


### PR DESCRIPTION
Hi @snoyberg This is a regression test for the problem in #38. 
I also already added the fix that you suggested and it does indeed seem to fix the issue.

I made this PR here because I couldn't reproduce the problem in `process` instead.
I'd be happy to close this PR here and open a similar one for https://github.com/haskell/process/pull/204 instead if we find a way to reproduce the issue there.