### PR TITLE
Improve the presentation of the documentation

### DIFF
--- a/src/System/Process/Typed.hs
+++ b/src/System/Process/Typed.hs
@@ -830,7 +830,9 @@ stopProcess = liftIO . pCleanup
 -- @since 0.2.5.0
 withProcessTerm :: (MonadUnliftIO m)
   => ProcessConfig stdin stdout stderr
+  -- ^
   -> (Process stdin stdout stderr -> m a)
+  -- ^
   -> m a
 withProcessTerm config = bracket (startProcess config) stopProcess
 

--- a/src/System/Process/Typed.hs
+++ b/src/System/Process/Typed.hs
@@ -71,18 +71,22 @@ module System.Process.Typed
     , startProcess
     , stopProcess
     , withProcessWait
-    , withProcessWait_
     , withProcessTerm
-    , withProcessTerm_
     , readProcess
-    , readProcess_
     , runProcess
-    , runProcess_
     , readProcessStdout
-    , readProcessStdout_
     , readProcessStderr
-    , readProcessStderr_
     , readProcessInterleaved
+      -- ** Exception-throwing functions
+      -- | The functions ending in underbar (@_@) are the same as
+      -- their counterparts without underbar but instead of returning
+      -- an 'ExitCode' they throw 'ExitCodeException' on failure.
+    , withProcessWait_
+    , withProcessTerm_
+    , readProcess_
+    , runProcess_
+    , readProcessStdout_
+    , readProcessStderr_
     , readProcessInterleaved_
 
       -- * Interact with a process

--- a/src/System/Process/Typed.hs
+++ b/src/System/Process/Typed.hs
@@ -68,26 +68,26 @@ module System.Process.Typed
     , mkStreamSpec
 
       -- * Launch a process
-    , startProcess
-    , stopProcess
-    , withProcessWait
-    , withProcessTerm
-    , readProcess
     , runProcess
+    , readProcess
     , readProcessStdout
     , readProcessStderr
     , readProcessInterleaved
+    , withProcessWait
+    , withProcessTerm
+    , startProcess
+    , stopProcess
       -- ** Exception-throwing functions
       -- | The functions ending in underbar (@_@) are the same as
       -- their counterparts without underbar but instead of returning
       -- an 'ExitCode' they throw 'ExitCodeException' on failure.
-    , withProcessWait_
-    , withProcessTerm_
-    , readProcess_
     , runProcess_
+    , readProcess_
     , readProcessStdout_
     , readProcessStderr_
     , readProcessInterleaved_
+    , withProcessWait_
+    , withProcessTerm_
 
       -- * Interact with a process
 

--- a/src/System/Process/Typed.hs
+++ b/src/System/Process/Typed.hs
@@ -684,7 +684,7 @@ useHandleClose h = mkStreamSpec (P.UseHandle h) $ \_ Nothing -> return ((), hClo
 -- | Launch a process based on the given 'ProcessConfig'. You should
 -- ensure that you call 'stopProcess' on the result. It's usually
 -- better to use one of the functions in this module which ensures
--- 'stopProcess' is called, such as 'withProcess'.
+-- 'stopProcess' is called, such as 'withProcessWait'.
 --
 -- @since 0.1.0.0
 startProcess :: MonadIO m

--- a/src/System/Process/Typed.hs
+++ b/src/System/Process/Typed.hs
@@ -74,8 +74,6 @@ module System.Process.Typed
     , withProcessWait_
     , withProcessTerm
     , withProcessTerm_
-    , withProcess
-    , withProcess_
     , readProcess
     , readProcess_
     , runProcess
@@ -107,6 +105,9 @@ module System.Process.Typed
     , ByteStringOutputException (..)
       -- * Unsafe functions
     , unsafeProcessHandle
+      -- * Deprecated functions
+    , withProcess
+    , withProcess_
     ) where
 
 import qualified Data.ByteString as S


### PR DESCRIPTION
This PR improves (in my opinion) the presentation of the documentation:

* It moves the deprecated functions out of the way to the bottom of the page
* It separates the exception-throwing functions into their own section
* It orders the functions so that the ones that a user is more likely to want are closer to the top

I would be interested to know what you think.