### PR TITLE
Show empty argument

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for typed-process
 
+## 0.2.7.0
+
+* Include empty argument in the show instance.
+
 ## 0.2.6.3
 
 * Doc improvements

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:        typed-process
-version:     0.2.6.3
+version:     0.2.7.0
 synopsis:    Run external processes, with strong typing of streams
 description: Please see the tutorial at <https://github.com/fpco/typed-process#readme>
 category:    System

--- a/src/System/Process/Typed.hs
+++ b/src/System/Process/Typed.hs
@@ -226,6 +226,7 @@ instance Show (ProcessConfig stdin stdout stderr) where
       where
         escape x
             | any (`elem` " \\\"'") x = show x
+            | x == "" = "\"\""
             | otherwise = x
 instance (stdin ~ (), stdout ~ (), stderr ~ ())
   => IsString (ProcessConfig stdin stdout stderr) where

--- a/test/System/Process/TypedSpec.hs
+++ b/test/System/Process/TypedSpec.hs
@@ -166,3 +166,7 @@ spec = do
 
         let expected = "stdout\nstderr\nstdout\n"
         L.take (L.length expected) lbs1 `shouldBe` expected
+
+    it "empty param are showed" $
+      let expected = "Raw command: podman exec --detach-keys \"\" ctx bash\n"
+       in show (proc "podman" ["exec", "--detach-keys", "", "ctx", "bash"]) `shouldBe` expected


### PR DESCRIPTION
This change correctly render command using empty arguments.
For example `podman exec --detach-keys "" ctx bash` was previously
showed as   `podman exec --detach-keys  ctx bash`.