### PR TITLE
Adds hpack generated cabal file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .stack-work/
 *~
 tarballs/
-/typed-process.cabal
 stack.yaml.lock

--- a/typed-process.cabal
+++ b/typed-process.cabal
@@ -1,0 +1,90 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.35.0.
+--
+-- see: https://github.com/sol/hpack
+
+name:           typed-process
+version:        0.2.10.1
+synopsis:       Run external processes, with strong typing of streams
+description:    Please see the tutorial at <https://github.com/fpco/typed-process#readme>
+category:       System
+homepage:       https://github.com/fpco/typed-process
+bug-reports:    https://github.com/fpco/typed-process/issues
+author:         Michael Snoyman
+maintainer:     michael@snoyman.com
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+    ChangeLog.md
+
+source-repository head
+  type: git
+  location: https://github.com/fpco/typed-process
+
+library
+  exposed-modules:
+      System.Process.Typed
+      System.Process.Typed.Internal
+  other-modules:
+      Paths_typed_process
+  hs-source-dirs:
+      src
+  build-depends:
+      async >=2.0
+    , base >=4.12 && <5
+    , bytestring
+    , process >=1.2
+    , stm
+    , transformers
+    , unliftio-core
+  default-language: Haskell2010
+  if os(windows)
+    cpp-options: -DWINDOWS
+
+test-suite typed-process-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      System.Process.TypedSpec
+      Paths_typed_process
+  hs-source-dirs:
+      test
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      async >=2.0
+    , base >=4.12 && <5
+    , base64-bytestring
+    , bytestring
+    , hspec
+    , process >=1.2
+    , stm
+    , temporary
+    , transformers
+    , typed-process
+    , unliftio-core
+  default-language: Haskell2010
+
+test-suite typed-process-test-single-threaded
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      System.Process.TypedSpec
+      Paths_typed_process
+  hs-source-dirs:
+      test
+  build-depends:
+      async >=2.0
+    , base >=4.12 && <5
+    , base64-bytestring
+    , bytestring
+    , hspec
+    , process >=1.2
+    , stm
+    , temporary
+    , transformers
+    , typed-process
+    , unliftio-core
+  default-language: Haskell2010


### PR DESCRIPTION
> [Should I check in generated cabal files?](https://docs.haskellstack.org/en/stable/stack_yaml_vs_cabal_package_file/#should-i-check-in-generated-cabal-files)
Yes, you should. This recommendation was changed in [issue #5210](https://github.com/commercialhaskell/stack/issues/5210), please see the discussion there.
