### PR TITLE
Add hspec-discover to build-tools

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -36,6 +36,8 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
+    build-tools:
+    - hspec-discover:hspec-discover >=2 && <3
     dependencies:
     - base64-bytestring
     - hspec
@@ -44,6 +46,8 @@ tests:
   typed-process-test-single-threaded:
     main: Spec.hs
     source-dirs: test
+    build-tools:
+    - hspec-discover:hspec-discover >=2 && <3
     dependencies:
     - base64-bytestring
     - hspec


### PR DESCRIPTION
Without that running the tests via Cabal fails with: could not execute: hspec-discover
Moved these changes from https://github.com/fpco/typed-process/pull/63 to a separate PR as suggest in https://github.com/fpco/typed-process/pull/63#issuecomment-1445366991.