### PR TITLE
Check in generated Cabal file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .stack-work/
 *~
+dist-newstyle/
 tarballs/
-/typed-process.cabal
 stack.yaml.lock

--- a/typed-process.cabal
+++ b/typed-process.cabal
@@ -1,0 +1,90 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.35.2.
+--
+-- see: https://github.com/sol/hpack
+
+name:           typed-process
+version:        0.2.10.1
+synopsis:       Run external processes, with strong typing of streams
+description:    Please see the tutorial at <https://github.com/fpco/typed-process#readme>
+category:       System
+homepage:       https://github.com/fpco/typed-process
+bug-reports:    https://github.com/fpco/typed-process/issues
+author:         Michael Snoyman
+maintainer:     michael@snoyman.com
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+    ChangeLog.md
+
+source-repository head
+  type: git
+  location: https://github.com/fpco/typed-process
+
+library
+  exposed-modules:
+      System.Process.Typed
+      System.Process.Typed.Internal
+  other-modules:
+      Paths_typed_process
+  hs-source-dirs:
+      src
+  build-depends:
+      async >=2.0
+    , base >=4.12 && <5
+    , bytestring
+    , process >=1.2
+    , stm
+    , transformers
+    , unliftio-core
+  default-language: Haskell2010
+  if os(windows)
+    cpp-options: -DWINDOWS
+
+test-suite typed-process-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      System.Process.TypedSpec
+      Paths_typed_process
+  hs-source-dirs:
+      test
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      async >=2.0
+    , base >=4.12 && <5
+    , base64-bytestring
+    , bytestring
+    , hspec
+    , process >=1.2
+    , stm
+    , temporary
+    , transformers
+    , typed-process
+    , unliftio-core
+  default-language: Haskell2010
+
+test-suite typed-process-test-single-threaded
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      System.Process.TypedSpec
+      Paths_typed_process
+  hs-source-dirs:
+      test
+  build-depends:
+      async >=2.0
+    , base >=4.12 && <5
+    , base64-bytestring
+    , bytestring
+    , hspec
+    , process >=1.2
+    , stm
+    , temporary
+    , transformers
+    , typed-process
+    , unliftio-core
+  default-language: Haskell2010


### PR DESCRIPTION
See https://github.com/commercialhaskell/stack/issues/5210 and https://www.fpcomplete.com/blog/storing-generated-cabal-files/ for the rationale behind this.
Moved these changes from https://github.com/fpco/typed-process/pull/63 to a separate PR as suggest in https://github.com/fpco/typed-process/pull/63#issuecomment-1445366991.