### PR TITLE
refactoring: Use `tryJust` instead of pattern guards

### DIFF
--- a/src/System/Process/Typed.hs
+++ b/src/System/Process/Typed.hs
@@ -273,7 +273,7 @@ startProcess pConfig'@ProcessConfig {..} = liftIO $ do
                                 -- runtime!
                                 | isPermissionError e && not multiThreadedRuntime && isWindows ->
                                   P.waitForProcess pHandle
-                                | otherwise -> throwIO e
+                                | otherwise -> throwIO e >> P.waitForProcess pHandle
                               Right () -> P.waitForProcess pHandle
                           success <- atomically $ tryPutTMVar pExitCode ec
                           evaluate $ assert success ()

--- a/src/System/Process/Typed.hs
+++ b/src/System/Process/Typed.hs
@@ -257,8 +257,7 @@ startProcess pConfig'@ProcessConfig {..} = liftIO $ do
                       -- then call waitForProcess ourselves
                       Left _ -> do
                           eres <- try $ P.terminateProcess pHandle
-                          ec <-
-                            case eres of
+                          case eres of
                               Left e
                                 -- On Windows, with the single-threaded runtime, it
                                 -- seems that if a process has already exited, the
@@ -272,9 +271,10 @@ startProcess pConfig'@ProcessConfig {..} = liftIO $ do
                                 -- Recommendation: always use the multi-threaded
                                 -- runtime!
                                 | isPermissionError e && not multiThreadedRuntime && isWindows ->
-                                  P.waitForProcess pHandle
-                                | otherwise -> throwIO e >> P.waitForProcess pHandle
-                              Right () -> P.waitForProcess pHandle
+                                  pure ()
+                                | otherwise -> throwIO e
+                              Right () -> pure ()
+                          ec <- P.waitForProcess pHandle
                           success <- atomically $ tryPutTMVar pExitCode ec
                           evaluate $ assert success ()
 


### PR DESCRIPTION
Doing this first will give us a smaller diff for #70, hopefully putting us into a better position to make progress there.

This reduces the diff for #70 to essentially: https://github.com/sol/typed-process/commit/4c5d917b740d4258865027ddff49f2848780edfe

But ignoring #70 for a moment, I still think this is a reasonable improvement.