### PR TITLE
Run tests in parallel + get rid of `-with-rtsopts=-N` (fixes #59)

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -35,11 +35,9 @@ tests:
     source-dirs: test
     ghc-options:
     - -threaded
-    - -rtsopts
-    - -with-rtsopts=-N
     dependencies:
     - base64-bytestring
-    - hspec == 2.*
+    - hspec >= 2.8.3 && < 3
     - temporary
     - typed-process
   typed-process-test-single-threaded:

--- a/test/SpecHook.hs
+++ b/test/SpecHook.hs
@@ -1,0 +1,7 @@
+module SpecHook where
+
+import           Test.Hspec
+import           GHC.Conc
+
+hook :: Spec -> Spec
+hook spec = runIO (getNumProcessors >>= setNumCapabilities) >> parallel spec


### PR DESCRIPTION
This addresses #59 without resorting to package flags.

It also runs the test in parallel, decreasing the total time from two seconds to one second.