### PR TITLE
Format ExitCodeException stdout and stderr with UTF-8

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for typed-process
 
+* Format stdout and stderr in `ExitCodeException` assuming they are in
+  UTF-8.  See [#87](https://github.com/fpco/typed-process/pull/87).
+  Thanks to @9999years for the legwork on this change.
+
 ## 0.2.12.0
 
 * Add `getPid`, `exitCodeExceptionWithOutput`,

--- a/package.yaml
+++ b/package.yaml
@@ -19,6 +19,7 @@ dependencies:
 - bytestring
 - process >=1.2
 - stm
+- text
 - transformers
 - unliftio-core
 

--- a/src/System/Process/Typed/Internal.hs
+++ b/src/System/Process/Typed/Internal.hs
@@ -620,11 +620,13 @@ instance Show ExitCodeException where
         , show (eceProcessConfig ece) { pcEnv = Nothing }
         , if L.null (eceStdout ece)
             then ""
-            else "Standard output:\n\n" ++ L8.unpack (eceStdout ece)
+            else "Standard output:\n\n" ++ unpack (eceStdout ece)
         , if L.null (eceStderr ece)
             then ""
-            else "Standard error:\n\n" ++ L8.unpack (eceStderr ece)
+            else "Standard error:\n\n" ++ unpack (eceStderr ece)
         ]
+      where
+        unpack = L8.unpack
 
 -- | Wrapper for when an exception is thrown when reading from a child
 -- process, used by 'byteStringOutput'.

--- a/src/System/Process/Typed/Internal.hs
+++ b/src/System/Process/Typed/Internal.hs
@@ -23,9 +23,11 @@ import Control.Concurrent.Async (async)
 import Control.Concurrent.STM (newEmptyTMVarIO, atomically, putTMVar, readTMVar, STM, tryPutTMVar, throwSTM)
 import System.Exit (ExitCode)
 import qualified Data.ByteString.Lazy as L
-import qualified Data.ByteString.Lazy.Char8 as L8
 import Data.String (IsString (fromString))
 import Control.Monad.IO.Unlift
+import qualified Data.Text.Encoding.Error as TEE
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text.Lazy.Encoding as TLE
 
 #if MIN_VERSION_process(1, 4, 0) && !WINDOWS
 import System.Posix.Types (GroupID, UserID)
@@ -626,7 +628,9 @@ instance Show ExitCodeException where
             else "Standard error:\n\n" ++ unpack (eceStderr ece)
         ]
       where
-        unpack = L8.unpack
+        -- Format with UTF-8, because we have to choose some encoding,
+        -- and UTF-8 is the least likely to be wrong in general.
+        unpack = TL.unpack . TLE.decodeUtf8With TEE.lenientDecode
 
 -- | Wrapper for when an exception is thrown when reading from a child
 -- process, used by 'byteStringOutput'.


### PR DESCRIPTION
Closes https://github.com/fpco/typed-process/issues/86

Before:

```
ghci> readProcess_ (shell "echo привет;echo 😑 1>&2 ; exit 1")
*** Exception: Received ExitFailure 1 when running
Shell command: echo привет;echo 😑 1>&2 ; exit 1
Standard output:

Ð¿ÑÐ¸Ð²ÐµÑ
Standard error:

ð

```

After:

```
ghci> readProcess_ (shell "echo привет;echo 😑 1>&2 ; exit 1")
*** Exception: Received ExitFailure 1 when running
Shell command: echo привет;echo 😑 1>&2 ; exit 1
Standard output:

привет
Standard error:

😑

```