### PR TITLE
Decode as UTF-8 in `ExitCodeException`'s `Show` instance

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -21,6 +21,7 @@ dependencies:
 - stm
 - transformers
 - unliftio-core
+- text
 
 library:
   source-dirs: src


### PR DESCRIPTION
Partial fix for https://github.com/fpco/typed-process/issues/86. This isn't perfect (for retrocomputing you may want another character encoding) but improves the behavior in many circumstances.

Requires #88.